### PR TITLE
Make interop calls internal, plus some other minor bits.

### DIFF
--- a/dotnet/src/Extism.Sdk/LibExtism.cs
+++ b/dotnet/src/Extism.Sdk/LibExtism.cs
@@ -5,7 +5,7 @@ namespace Extism.Sdk.Native;
 /// <summary>
 /// Functions exposed by the native Extism library.
 /// </summary>
-public static class LibExtism
+internal static class LibExtism
 {
     /// <summary>
     /// Create a new context.


### PR DESCRIPTION
Make LibExtism internal, along with all NativeHandle properties since Context and Plugin classes provide comprehensive wrappers for the underlying library and manage the associated handles; generally `DllImport` methods should always be internal.

Also implement thread-safe dispose semantics and verify Context and Plugin have not been disposed when invoking methods.

Noticed while making these changes; extism isn't thread-safe, you can't call a plugin from two threads at once, so not sure if a higher-level wrapper needs to manage/compensate for that.

I'd also be tempted to multi-target `netstandard2.1` and `net7.0` so users can get the source-generated `LibraryImport` attribute rather than `DllImport` on platforms that support it. Thoughts, @mhmd-azeez?